### PR TITLE
Initial draft of a Security Working Group governance

### DIFF
--- a/.github/ISSUE_TEMPLATE/add_project.md
+++ b/.github/ISSUE_TEMPLATE/add_project.md
@@ -1,0 +1,24 @@
+---
+name: Project addition request
+about: Request addition of project to ROS 2 Security Working Group
+title: 'REQUEST: Add project <NAME>'
+labels: add-project
+assignees: ''
+---
+
+### Description
+- What is this project?
+- What is your motivation for wanting it under the Security Working Group?
+
+### Existing URL
+e.g. https://github.com/some-org/some-project.git
+
+### Requirements
+- [ ] Builds on ROS 2 master with no warnings
+- [ ] Has linters enabled
+- [ ] `colcon test` runs successfully
+- [ ] Test coverage is greated than 50%
+
+### Sponsors (if applicable)
+- (at)sponsor-1
+- (at)sponsor-2

--- a/.github/ISSUE_TEMPLATE/membership.md
+++ b/.github/ISSUE_TEMPLATE/membership.md
@@ -1,0 +1,24 @@
+---
+name: Organization Membership Request
+about: Request membership in ROS 2 Security Working Group
+title: 'REQUEST: New/alter membership'
+labels: membership
+assignees: ''
+---
+
+### Request
+- Are you looking to become a member?
+- Are you looking to move from one Working Group role to another (e.g. member to reviewer)?
+
+### Requirements
+- [ ] I have enabled 2FA on my GitHub account (https://github.com/settings/security)
+- [ ] I am actively contributing to 1 or more projects under the ROS 2 Security Working Group
+
+### Sponsors (if applicable)
+- (at)sponsor-1
+- (at)sponsor-2
+
+### List of contributions to ROS 2 Security Working Group
+- PRs reviewed / authored
+- Issues triaged
+- Other relevant project involvement

--- a/README.md
+++ b/README.md
@@ -11,22 +11,18 @@ A significant portion of the Security Working Group's mission is achieved by mai
 Although the following ROS subprojects have links to security, they are not governed by the Security Working Group:
  * _TBD_
 
-### Adding New Subprojects
-New subprojects must follow the following workflow to be added to the Security Working Group:
-* Identify a subproject lead and a sub-team to own the subproject.  Single-person subproject teams are allowed.
-* Work with an Approver to scope the project and create a pull request.
-* The subproject lead must introduce the new subproject at the next Security Working Group meeting; the pull request may or may not be queued until the meeting.
-
-### Maintaining Subprojects
-Approved subprojects must these criteria:
-* Build passes against ROS2 master
-* The ROS2 standard linter set is enabled and adhered to
-* Builds have 0 warnings
-* Quality builds are green (address sanitizer, thread sanitizer, clang thread safety analysis)
-* Test suite passes
-* Reasonable* code coverage is met by test suites
-* Issues are responded to promptly*
-* Releases go out regularly* when bugfixes or new features are introduced
+### Adding and Maintaining Subprojects
+Subprojects must meet the following criteria:
+* An Approver can add or create a new subproject that will be maintained by this working group.
+* A Member should introduce new subprojects at the next Security Working Group meeting
+* Builds must pass against ROS2 master
+* The ROS2 standard linter set must be enabled and adhered to
+* Builds must have 0 warnings
+* Quality builds must be green (address sanitizer, thread sanitizer, clang thread safety analysis)
+* Test suite must pass
+* Reasonable* code coverage must be met by test suites
+* Issues must be responded to promptly*
+* Releases must go out regularly* when bugfixes or new features are introduced
 
 _*-Precise definition of term not determined_
 
@@ -54,14 +50,13 @@ Security Working Group members may act in one or more of the following roles:
   * Contributors do not need to particpate in the Working Group beyond contributing code.
 * __Member__:  A participant in Security Working Group discussions.  Responsiblities include:
   * Attending a majority of the Security Working Group meetings
-  * Commenting on pull requests
-  * Any Approver may invite new Member to join the Working Group
   * New members should be recognized at the next Security Working Group meeting
 * __Reviewer__:  Responsible for reviewing pull requests
-  * _TBD_
+  * Review and comment on pull requests
   * Triage vulnerability reports
 * __Approver__:  Responsible for approving pull requests
   * All approvers are also reviewers
+  * Approvers can add members to the Working Group
   * Only approvers can create pull requests
 * __Moderator__:  Responsible for facilitating the governance structure.
   * Granting and removing access

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ROS 2 Security Working Group
-The Security Working Group's mission is to advocate for and implement security features within ROS 2.  The working group negotiates a balance between the benefits of security and the enablement of technology, striving for a secure-by-default design which can be customized to suit a targeted security profile.
+The Security Working Group's mission is to advocate for and implement security features within ROS 2. The working group negotiates a balance between the benefits of security and the enablement of technology, striving for a secure-by-default design which can be customized to suit a targeted security profile.
 
-This document outlines the governance of the ROS 2 Security Working Group.  Updates to this document will be handled in the same manner as other project updates governed by the Working Group.
+This document outlines the governance of the ROS 2 Security Working Group. Updates to this document will be handled in the same manner as other project updates governed by the Working Group.
 
 ## Subprojects
-A significant portion of the Security Working Group's mission is achieved by maintaining ROS projects.  The following projects are owned by this Working Group:
+A significant portion of the Security Working Group's mission is achieved by maintaining ROS projects. The following projects are owned by this Working Group:
 * _TBD:  list of project names_
 
 ### Adding subprojects

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ROS 2 Security Working Group
-The Security Working Group's mission is to advocate for and implement security features within ROS 2.  The working group negotiates a balance between the benefits of and the enablement of technology, striving for a secure-by-default design which can be customized to suit a targeted security profile.
+The Security Working Group's mission is to advocate for and implement security features within ROS 2.  The working group negotiates a balance between the benefits of security and the enablement of technology, striving for a secure-by-default design which can be customized to suit a targeted security profile.
 
 This document outlines the governance of the ROS 2 Security Working Group.  Updates to this document will be handled in the same manner as other project updates governed by the Working Group.
 
@@ -49,8 +49,9 @@ This guidelines are designed exclusively to help the Working Group achieve its m
 ### Roles
 Security Working Group members may act in one or more of the following roles:
 * __Contributor__:  A person contributing code to the Security Working Group subprojects
-  * Timely response to comments
-  * Contribute code to one or more subprojects
+  * Timely response to comments.
+  * Contribute code to one or more subprojects.
+  * Contributors do not need to particpate in the Working Group beyond contributing code.
 * __Member__:  A participant in Security Working Group discussions.  Responsiblities include:
   * Attending a majority of the Security Working Group meetings
   * Commenting on pull requests

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The Security Working Group has a few communication channels:
 ### Roles
 Security Working Group members may act in one or more of the following roles:
 * __Member__
-  * Attend a majority of the Security Working Group meetings
+  * Attend at least one out of the last three Security Working Group meetings
   * Responsible for triaging issues
 * __Reviewer__
   * All reviewers are members

--- a/README.md
+++ b/README.md
@@ -4,62 +4,40 @@ The Security Working Group's mission is to advocate for and implement security f
 This document outlines the governance of the ROS 2 Security Working Group.  Updates to this document will be handled in the same manner as other project updates governed by the Working Group.
 
 ## Subprojects
-A significant portion of the Security Working Group's mission is achieved by maintaining ROS subprojects.  The following subprojects are owned by this Working Group:
- * _TBD:  list project names and team leads_
+A significant portion of the Security Working Group's mission is achieved by maintaining ROS projects.  The following projects are owned by this Working Group:
+* _TBD:  list of project names_
 
-### Out of Scope
-Although the following ROS subprojects have links to security, they are not governed by the Security Working Group:
- * _TBD_
+### Adding subprojects
+To request that the Security Working Group take on ownership and maintainership of a particular project, create a new issue in this repository using the appropriate issue template. You may be requested to present your proposal at the next Security Working Group meeting. Approvers will vote on whether or not the Working Group will accept the project.
 
-### Adding and Maintaining Subprojects
+### Standards for subprojects
 Subprojects must meet the following criteria:
-* An Approver can add or create a new subproject that will be maintained by this working group.
-* A Member should introduce new subprojects at the next Security Working Group meeting
-* Builds must pass against ROS2 master
-* The ROS2 standard linter set must be enabled and adhered to
-* Builds must have 0 warnings
-* Quality builds must be green (address sanitizer, thread sanitizer, clang thread safety analysis)
+* Builds must pass against ROS 2 master
 * Test suite must pass
-* Reasonable* code coverage must be met by test suites
-* Issues must be responded to promptly*
-* Releases must go out regularly* when bugfixes or new features are introduced
-
-_*-Precise definition of term not determined_
-
-## Vulnerability Handling
-The Security Working Group is responsible for handling vulnerability reports filed against ROS.  Until a more comprehensive vulnerability handling program is established, the Working Group will perform the following:
-* Maintain a publicly accessible email address for securely reporting vulnerability details.
-* A Reviewer will triage reported vulnerabilities within a reasonable time and assign the vulnerability to a work queue
-* As part of the triage, the reviewer will propose a [CVSS Base Score](https://www.first.org/cvss/calculator/3.1) for the vulnerability
-* For high risk vulnerabilities (CVSS score 9.0 and above), the Reivewer will track remediation progress.
-* For high risk vulnerabilities, the Working Group Moderator will work with the broader ROS community to communicate when the patch is released and the potential impact.
+* Test coverage must be greater than 50%
+* The ROS 2 standard linter set must be enabled and adhered to
+* Builds must have 0 warnings
 
 ## Governance
-This guidelines are designed exclusively to help the Working Group achieve its mission, but are subject to change should they become cumbersome or ineffective.
+These guidelines are designed exclusively to help the Working Group achieve its mission, but are subject to change should they become cumbersome or ineffective.
 
 ### Meetings
- * The working group typically meets on the second week of each month
- * Meetings are announced on discourse.ros.org using the [wg-security tag](https://discourse.ros.org/tags/wg-security)
- * Meeting notes are kept on the [ROS Wiki](http://wiki.ros.org/ROS2/WorkingGroups/Security)
+* The working group typically meets on the last Tuesday of each month, at alternating times to accomodate our community's varied timezones
+* Meetings are announced and an agenda created on the ROS Discourse using the [wg-security tag](https://discourse.ros.org/tags/wg-security)
+* Meeting notes are kept on the [ROS Wiki](http://wiki.ros.org/ROS2/WorkingGroups/Security)
+* Meetings are recorded and available [on YouTube](https://www.youtube.com/playlist?list=PLpUh4ScdBhSMaEekJ8xeAAGmWUgR9S1K_)
 
 ### Roles
 Security Working Group members may act in one or more of the following roles:
-* __Contributor__:  A person contributing code to the Security Working Group subprojects
-  * Timely response to comments.
-  * Contribute code to one or more subprojects.
-  * Contributors do not need to particpate in the Working Group beyond contributing code.
-* __Member__:  A participant in Security Working Group discussions.  Responsiblities include:
-  * Attending a majority of the Security Working Group meetings
-  * New members should be recognized at the next Security Working Group meeting
-* __Reviewer__:  Responsible for reviewing pull requests
-  * Review and comment on pull requests
-  * Triage vulnerability reports
-* __Approver__:  Responsible for approving pull requests
-  * All approvers are also reviewers
-  * Approvers can add members to the Working Group
-  * Only approvers can create pull requests
-* __Moderator__:  Responsible for facilitating the governance structure.
-  * Granting and removing access
-  * Schedule Working Group meetings
-  * Ensure someone from the Security WG attends the ROS TSG
-  * Although a single person normally acts as Moderator, at least one alternate individual must be assigned Moderator rights.
+* __Member__
+  * Attend a majority of the Security Working Group meetings
+  * Responsible for triaging issues
+* __Reviewer__
+  * All reviewers are members
+  * Responsible for reviewing pull requests
+* __Approver__
+  * All approvers are reviewers
+  * Responsible for approving and merging pull requests
+  * Responsible for vetting and accepting new projects into the Working Group
+
+To become a member or change role, create an issue in this repository using the appropriate issue template.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,61 @@
-# community
+# ROS 2 Security Working Group
+The Security Working Group's mission is to advocate for and implement security features within ROS 2.  The working group negotiates a balance between benefits of security benefits and enabling technology, striving for a secure-by-default design which can be further customized to suit a system's security profile.
+
+This document outlines the governance of the ROS 2 Security Working Group.  Updates to this document will be handled in the same manner as other project updates governed by the Working Group.
+
+## Subprojects
+A significant part of the Security Working Group's mission is achieved by maintaining ROS subprojects.  The following subprojects are owned by this Working Group:
+ * _TBD:  Project name and team lead_
+
+### Out of Scope
+Although the following ROS subprojects have links to security, they are not governed by the Security Working Group:
+ * _TBD_
+
+### Adding New Subprojects
+New subprojects must follow the following workflow to be added to the Security Working Group:
+* Identify an existing Approver, a project lead and a sub-team to own the subproject (team size may be as small as one)
+* Propose the new project to one or more Approvers
+* The Approver creates a pull request
+* The project lead must disuss the new subproject at the next Security Working Group meeting
+
+### Maintaining Subprojects
+Approved subprojects projects must these criteria:
+* Build passes against ROS2 master
+* The ROS2 standard linter set is enabled and adhered to
+* Builds have 0 warnings
+* Quality builds are green (address sanitizer, thread sanitizer, clang thread safety analysis)
+* Test suite passes
+* Reasonable* code coverage is met by test suites
+* Issues are responded to promptly*
+* Releases go out regularly* when bugfixes or new features are introduced
+
+*-Precise definition of term not determined
+
+### Vulnerability Handling
+When a vulnerability has been identified in a subproject owned by the Security Working Group, the vulnerability will be triaged by one or more Approvers.
+
+## Meetings
+ * The working group typically meets on the second week of each month
+ * Meetings are announced with the [wg-security tag](https://discourse.ros.org/tags/wg-security) on discourse.ros.org
+ * Meeting notes are kept on the [ROS Wiki](http://wiki.ros.org/ROS2/WorkingGroups/Security)
+
+## Governance
+
+
+### Membership
+The following is required to remain a member of the Security Working Group:
+* _TBD_
+
+### Roles
+Security Working Group members may act in one or more of the following roles:
+* Contributor
+  * _TBD_
+* Member
+  * Attend at least 50% of the Security Working Group meetings
+* Reviewer
+  * _TBD_
+* Approver
+  * All approvers are also reviewers
+  * Only approvers can create pull requests
+* Moderator
+  * _[This is Joe]_

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ These guidelines are designed exclusively to help the Working Group achieve its 
 * Meeting notes are kept on the [ROS Wiki](http://wiki.ros.org/ROS2/WorkingGroups/Security)
 * Meetings are recorded and available [on YouTube](https://www.youtube.com/playlist?list=PLpUh4ScdBhSMaEekJ8xeAAGmWUgR9S1K_)
 
+### Communication channel
+The Security Working Group has a few communication channels:
+* ROS Discourse using the [wg-security tag](https://discourse.ros.org/tags/wg-security)
+* Chat using a [Matrix room](https://matrix.to/#/!LcRLnAIRWjSCfZmMeD:matrix.org?via=matrix.org)
+
 ### Roles
 Security Working Group members may act in one or more of the following roles:
 * __Member__

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # ROS 2 Security Working Group
-The Security Working Group's mission is to advocate for and implement security features within ROS 2.  The working group negotiates a balance between benefits of security benefits and enabling technology, striving for a secure-by-default design which can be further customized to suit a system's security profile.
+The Security Working Group's mission is to advocate for and implement security features within ROS 2.  The working group negotiates a balance between the benefits of and the enablement of technology, striving for a secure-by-default design which can be customized to suit a targeted security profile.
 
 This document outlines the governance of the ROS 2 Security Working Group.  Updates to this document will be handled in the same manner as other project updates governed by the Working Group.
 
 ## Subprojects
-A significant part of the Security Working Group's mission is achieved by maintaining ROS subprojects.  The following subprojects are owned by this Working Group:
- * _TBD:  Project name and team lead_
+A significant portion of the Security Working Group's mission is achieved by maintaining ROS subprojects.  The following subprojects are owned by this Working Group:
+ * _TBD:  list project names and team leads_
 
 ### Out of Scope
 Although the following ROS subprojects have links to security, they are not governed by the Security Working Group:
@@ -13,13 +13,12 @@ Although the following ROS subprojects have links to security, they are not gove
 
 ### Adding New Subprojects
 New subprojects must follow the following workflow to be added to the Security Working Group:
-* Identify an existing Approver, a project lead and a sub-team to own the subproject (team size may be as small as one)
-* Propose the new project to one or more Approvers
-* The Approver creates a pull request
-* The project lead must disuss the new subproject at the next Security Working Group meeting
+* Identify a subproject lead and a sub-team to own the subproject.  Single-person subproject teams are allowed.
+* Work with an Approver to scope the project and create a pull request.
+* The subproject lead must introduce the new subproject at the next Security Working Group meeting; the pull request may or may not be queued until the meeting.
 
 ### Maintaining Subprojects
-Approved subprojects projects must these criteria:
+Approved subprojects must these criteria:
 * Build passes against ROS2 master
 * The ROS2 standard linter set is enabled and adhered to
 * Builds have 0 warnings
@@ -29,33 +28,42 @@ Approved subprojects projects must these criteria:
 * Issues are responded to promptly*
 * Releases go out regularly* when bugfixes or new features are introduced
 
-*-Precise definition of term not determined
+_*-Precise definition of term not determined_
 
-### Vulnerability Handling
-When a vulnerability has been identified in a subproject owned by the Security Working Group, the vulnerability will be triaged by one or more Approvers.
-
-## Meetings
- * The working group typically meets on the second week of each month
- * Meetings are announced with the [wg-security tag](https://discourse.ros.org/tags/wg-security) on discourse.ros.org
- * Meeting notes are kept on the [ROS Wiki](http://wiki.ros.org/ROS2/WorkingGroups/Security)
+## Vulnerability Handling
+The Security Working Group is responsible for handling vulnerability reports filed against ROS.  Until a more comprehensive vulnerability handling program is established, the Working Group will perform the following:
+* Maintain a publicly accessible email address for securely reporting vulnerability details.
+* A Reviewer will triage reported vulnerabilities within a reasonable time and assign the vulnerability to a work queue
+* As part of the triage, the reviewer will propose a [CVSS Base Score](https://www.first.org/cvss/calculator/3.1) for the vulnerability
+* For high risk vulnerabilities (CVSS score 9.0 and above), the Reivewer will track remediation progress.
+* For high risk vulnerabilities, the Working Group Moderator will work with the broader ROS community to communicate when the patch is released and the potential impact.
 
 ## Governance
+This guidelines are designed exclusively to help the Working Group achieve its mission, but are subject to change should they become cumbersome or ineffective.
 
-
-### Membership
-The following is required to remain a member of the Security Working Group:
-* _TBD_
+### Meetings
+ * The working group typically meets on the second week of each month
+ * Meetings are announced on discourse.ros.org using the [wg-security tag](https://discourse.ros.org/tags/wg-security)
+ * Meeting notes are kept on the [ROS Wiki](http://wiki.ros.org/ROS2/WorkingGroups/Security)
 
 ### Roles
 Security Working Group members may act in one or more of the following roles:
-* Contributor
+* __Contributor__:  A person contributing code to the Security Working Group subprojects
+  * Timely response to comments
+  * Contribute code to one or more subprojects
+* __Member__:  A participant in Security Working Group discussions.  Responsiblities include:
+  * Attending a majority of the Security Working Group meetings
+  * Commenting on pull requests
+  * Any Approver may invite new Member to join the Working Group
+  * New members should be recognized at the next Security Working Group meeting
+* __Reviewer__:  Responsible for reviewing pull requests
   * _TBD_
-* Member
-  * Attend at least 50% of the Security Working Group meetings
-* Reviewer
-  * _TBD_
-* Approver
+  * Triage vulnerability reports
+* __Approver__:  Responsible for approving pull requests
   * All approvers are also reviewers
   * Only approvers can create pull requests
-* Moderator
-  * _[This is Joe]_
+* __Moderator__:  Responsible for facilitating the governance structure.
+  * Granting and removing access
+  * Schedule Working Group meetings
+  * Ensure someone from the Security WG attends the ROS TSG
+  * Although a single person normally acts as Moderator, at least one alternate individual must be assigned Moderator rights.


### PR DESCRIPTION
This framework should outline the different roles & responsibilities within the Security Working Group.  The two primary jobs of the WG are to maintain subprojects and to handle all ROS vulnerabilities (both ROS1 and ROS2).

Most of the authority is vested in Approvers, they should be able to work independently and keep the overall working group informed during the monthly meetings.