### PR TITLE
Remove lead role

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A significant portion of the Security Working Group's mission is achieved by mai
 * _TBD:  list of project names_
 
 ### Adding subprojects
-To request that the Security Working Group take on ownership and maintainership of a particular project, create a new issue in this repository using the appropriate issue template. You may be requested to present your proposal at the next Security Working Group meeting. Approvers will vote on whether or not the Working Group will accept the project.
+To request that the Security Working Group take on ownership and maintainership of a particular project, create a new issue in this repository using the appropriate issue template. You may be requested to present your proposal at the next Security Working Group meeting. The Working Group will accept the project upon unanimous agreement by Approvers.
 
 ### Standards for subprojects
 Subprojects must meet the following criteria:
@@ -19,13 +19,15 @@ Subprojects must meet the following criteria:
 * Builds must have 0 warnings
 
 ## Governance
-These guidelines are designed exclusively to help the Working Group achieve its mission, but are subject to change should they become cumbersome or ineffective.
+The [chair of this Working Group](https://index.ros.org/doc/ros2/Governance/) is appointed by the ROS 2 Technical Steering Committee (TSC). In accordance with the [TSC charter](https://index.ros.org/doc/ros2/_downloads/f48e811f5e1a3760466483bf752f1a9e/ros2-tsc-charter.pdf), the chair is responsible for managing the Working Group. This includes organizing meetings, and ensuring that these guidelines, which are designed exclusively to help the Working Group achieve its mission, remain effective.
 
 ### Meetings
-* The working group typically meets on the last Tuesday of each month, at alternating times to accomodate our community's varied timezones
+* The working group typically meets twice a month, at alternating times to accomodate our community's varied timezones
 * Meetings are announced and an agenda created on the ROS Discourse using the [wg-security tag](https://discourse.ros.org/tags/wg-security)
+* To receive meeting invitations, join [ros-security-working-group-invites](https://groups.google.com/forum/#!forum/ros-security-working-group-invites)
 * Meeting notes are kept on the [ROS Wiki](http://wiki.ros.org/ROS2/WorkingGroups/Security)
 * Meetings are recorded and available [on YouTube](https://www.youtube.com/playlist?list=PLpUh4ScdBhSMaEekJ8xeAAGmWUgR9S1K_)
+* Meetings are open to the public, and anyone is welcome to join
 
 ### Communication channel
 The Security Working Group has a few communication channels:
@@ -44,10 +46,5 @@ Security Working Group members may act in one or more of the following roles:
   * All approvers are reviewers
   * Responsible for approving and merging pull requests
   * Responsible for vetting and accepting new projects into the Working Group
-* __Lead__
-  * Leader of the working group
-  * Responsible for reviewing membership applications
-  * Responsible for breaking ties
-  * Veto capability
 
-To become a member or change role, create an issue in this repository using the appropriate issue template. Note that one cannot apply to become __Lead__.
+To become a member or change role, create an issue in this repository using the appropriate issue template. Such applications are accepted upon unanimous agreement from Approvers, and are typically based on the applicant's history with the subprojects of the Working Group.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A significant portion of the Security Working Group's mission is achieved by mai
 * _TBD:  list of project names_
 
 ### Adding subprojects
-To request that the Security Working Group take on ownership and maintainership of a particular project, create a new issue in this repository using the appropriate issue template. You may be requested to present your proposal at the next Security Working Group meeting. The Working Group will accept the project upon unanimous agreement by Approvers.
+To request that the Security Working Group take on ownership and maintainership of a particular project, create a new issue in this repository using the appropriate issue template. You may be requested to present your proposal at the next Security Working Group meeting. The Working Group will accept the project upon unanimous agreement from Approvers.
 
 ### Standards for subprojects
 Subprojects must meet the following criteria:


### PR DESCRIPTION
It isn't a standard role like the others, in that it's focused on management of the Working Group itself more than the Working Group's projects. Move that discussion up into Governance. Also clarify voting system and make membership applications the responsibility of Approvers instead of the chair.